### PR TITLE
config: image proxy 삭제

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -30,6 +30,7 @@
     "react-hooks/exhaustive-deps": "off",
     "react/react-in-jsx-scope": "off",
     "import/prefer-default-export": "off",
+    "@next/next/no-img-element": "off",
     "import/no-unresolved": "off",
     "import/export": "off",
     "import/extensions": "off",

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -8,18 +8,6 @@ const nextConfig = {
       destination: `${process.env.BE_URL}/api/:path*`,
     },
   ],
-  images: {
-    remotePatterns: [
-      {
-        protocol: 'http',
-        hostname: '**',
-      },
-      {
-        protocol: 'https',
-        hostname: '**',
-      },
-    ],
-  },
 };
 
 module.exports = nextConfig;

--- a/client/src/components/Detail.tsx
+++ b/client/src/components/Detail.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import React from 'react';
 import styled from '@emotion/styled';
 import BREAK_POINT from '@/styles/breakpoint';
@@ -14,7 +13,7 @@ interface DetailProps {
 export default function Detail({ imgSrc, name, address, description }: DetailProps) {
   return (
     <Wrapper>
-      <Image src={imgSrc} alt="place-image" width={360} height={180} priority />
+      <img src={imgSrc} alt={name} />
       <Title>{name}</Title>
       <Content>
         <Row>
@@ -37,6 +36,10 @@ const Wrapper = styled.div`
   flex-direction: column;
   align-items: center;
   margin-top: 20px;
+  img {
+    width: 360px;
+    height: 180px;
+  }
   @media only screen and (max-width: ${BREAK_POINT.mobile}px) {
     margin-top: 10px;
   }

--- a/client/src/components/PlaceInfo.tsx
+++ b/client/src/components/PlaceInfo.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import BREAK_POINT from '@/styles/breakpoint';
@@ -29,14 +28,7 @@ export default function PlaceInfo({
     <Place>
       <InfoContainer>
         <ImageBox>
-          <Image
-            src={src}
-            alt="place-image"
-            width={160}
-            height={90}
-            priority
-            onError={handleImageError}
-          />
+          <img src={src} alt={name} onError={handleImageError} />
         </ImageBox>
         <Info>
           <TitleContainer>
@@ -81,6 +73,10 @@ const ImageBox = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  img {
+    width: 160px;
+    height: 90px;
+  }
   @media only screen and (max-width: ${BREAK_POINT.mobile}px) {
     width: 50%;
   }


### PR DESCRIPTION
# Issue 번호
#43 

# 작업한 내용 설명
- Next.js에서 제공하는 Image 컴포넌트를 사용하게 될 경우 이미지 url에 proxy설정을 해서 프론트엔드 서버를 거쳐서 이미지 요청을 하게됨

- 이과정에서 서버가 버티지 못하고 뻗음

- Image 컴포넌트 사용없이 img태그로 변경 (프론트엔드 서버 거치지 않고 직접 이미지 요청)
- 후에 LCP최적화 작업 필요
